### PR TITLE
Add scp_temp_dir as valid option

### DIFF
--- a/lib/chef/provisioning/ssh_driver/driver.rb
+++ b/lib/chef/provisioning/ssh_driver/driver.rb
@@ -262,7 +262,7 @@ class Chef
               end
 
               if machine_options[:transport_options][:options]
-                valid_fields = [:prefix, :ssh_pty_enable, :ssh_gateway]
+                valid_fields = [:prefix, :ssh_pty_enable, :ssh_gateway, :scp_temp_dir]
 
                 extras = machine_options[:transport_options][:options].keys - valid_fields
 


### PR DESCRIPTION
Adding a new option to chef-provisioning: chef/chef-provisioning#339

Since chef-provisioning-ssh rejects options it doesn't recognize, we need to update chef-provisioning-ssh as well.