### PR TITLE
Don't clobber options[:prefix] if set

### DIFF
--- a/lib/chef/provisioning/ssh_driver/driver.rb
+++ b/lib/chef/provisioning/ssh_driver/driver.rb
@@ -390,7 +390,7 @@ class Chef
           unless machine_options['transport_options']['is_windows']
             machine_options['transport_options']['options'] ||= {}
             unless machine_options['transport_options']['username'] == 'root'
-              machine_options['transport_options']['options']['prefix'] = 'sudo '
+              machine_options['transport_options']['options']['prefix'] ||= 'sudo '
             end
           end
           ensure_has_keys_or_password(machine_options['transport_options'])


### PR DESCRIPTION
If `machine_options['transport_options']['username']` is not 'root', then `machine_options['transport_options']['options']['prefix']` gets unconditionally set to 'sudo ', even if the user specified some other value in the recipe. Let's fix things so as to not clobber it.