### PR TITLE
Add :install_cached transport option

### DIFF
--- a/lib/chef/provisioning/ssh_driver/driver.rb
+++ b/lib/chef/provisioning/ssh_driver/driver.rb
@@ -5,6 +5,7 @@ require 'chef/provisioning/version'
 require 'chef/provisioning/machine/basic_machine'
 require 'chef/provisioning/machine/unix_machine'
 require 'chef/provisioning/machine/windows_machine'
+require 'chef/provisioning/convergence_strategy/install_cached'
 require 'chef/provisioning/convergence_strategy/install_msi'
 require 'chef/provisioning/convergence_strategy/install_sh'
 require 'chef/provisioning/transport/winrm'
@@ -137,6 +138,9 @@ class Chef
           if ssh_machine[:transport_options][:is_windows]
             Chef::Provisioning::ConvergenceStrategy::InstallMsi.
               new(ssh_machine[:convergence_options], config)
+          elsif ssh_machine[:transport_options][:install_cached]
+            Chef::Provisioning::ConvergenceStrategy::InstallCached.
+              new(ssh_machine[:convergence_options], config)
           else
             Chef::Provisioning::ConvergenceStrategy::InstallSh.
               new(ssh_machine[:convergence_options], config)
@@ -241,7 +245,9 @@ class Chef
                 valid = false
               end
 
-              valid_fields = [:is_windows, :host, :hostname, :ip_address, :username, :ssh_options, :options]
+              valid_fields = [:is_windows, :install_cached,
+                :host, :hostname, :ip_address, :username,
+                :ssh_options, :options]
 
               extras = machine_options[:transport_options].keys - valid_fields
 


### PR DESCRIPTION
#9 changed the default behavior from InstallCached to InstallSh, but I have some workflows for which InstallCached is preferable (see also chef/chef-provisioning#315). This pull request adds a new transport option called `:install_cached` which can be used to select InstallCached; the default remains InstallSh.