### PR TITLE
Add feature to store machine data in node attribute rather than file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ test/.chef/provisioning
 test/nodes
 test/clients
 test/.chef/local-mode-cache
+.project
+vendor/
+Gemfile.lock
+*.gem

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Chef::Provisioning::Ssh
 
-TODO: Write a gem description
+Provisions existing machines using SSH.
 
 ## Installation
 
@@ -22,13 +22,25 @@ Or install it yourself as:
 
 ## Usage
 
+### driver_url
+
+`with_driver 'ssh'` will store machine data in a file in the directory `.chef/provisioning/ssh`
+on the provisioning machine, with a reference
+to the file in the node attribute `node['chef_provisioning']['reference']['ssh_machine_file']`
+
+`with_driver 'ssh:/some/path'` will store machine data in the specified directory, with a 
+reference to the file as above.
+
+`with_driver 'ssh:chef'` will store all machine data in the node attribute 
+`node['chef_provisioning']['reference']`.
+
+### machine_options
+
 The `machine_options` for provisioning ssh now use the key `transport_options` which line up directly with the `transport_options` for chef-provisioning proper. 
 
-The `transport_options` key must be a *symbol*. 
+The `transport_options` key and sub-keys may be strings or symbols.
 
-Sub-keys should be *strings*.
-
-The transport_options can be viewed in the code for chef-provisioning here:
+The `transport_options` can be viewed in the code for chef-provisioning here:
 
 https://github.com/chef/chef-provisioning/blob/master/lib/chef/provisioning/transport/ssh.rb#L17-L34
 
@@ -161,7 +173,7 @@ In addition to host, ip_address and hostname are also additional options.
 
 To test it out, clone the repo:
 
-`git clone https://github.com/double-z/chef-provisioning-ssh.git`
+`git clone https://github.com/chef/chef-provisioning-ssh.git`
 
 in the test directory there is a Vagrantfile with 2 nodes. 
 
@@ -175,7 +187,7 @@ Then run from the test directory:
 
 `chef-client -z -o vagrant::test_ssh`
 
-NOTE: if the second machine fails it will be a result of issues with your vagrant key.
+NOTE: if the first machine fails it will likely be a result of issues with your vagrant key.
 
 This will run chef-provisioning on each of the two vagrant nodes.
 
@@ -183,9 +195,13 @@ thats it.
 
 party on wayne.
 
+Be aware, the `test_ssh` recipe is designed for testing, not to illustrate good practice. For example, you
+do not need to list all three actions `[ :ready, :setup, :converge ]` or specify `converge true`
+if you want the normal 'bootstrap if needed, converge if changed' behavior.
+
 ## Contributing
 
-1. Fork it ( http://github.com/double-z/chef-provisioning-ssh/fork )
+1. Fork it ( http://github.com/chef/chef-provisioning-ssh/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/chef-provisioning-ssh.gemspec
+++ b/chef-provisioning-ssh.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['README.md', 'LICENSE' ]
   s.summary = 'Provisioner for managing servers using ssh in Chef Provisioning.'
   s.description = s.summary
-  s.homepage = 'https://github.com/double-z/chef-provisioning-ssh'
+  s.homepage = 'https://github.com/chef/chef-provisioning-ssh'
 
   s.require_path  = "lib"
   s.bindir       = "bin"
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
   s.files = %w(Rakefile LICENSE README.md Gemfile) + Dir.glob("*.gemspec") +
       Dir.glob("{distro,lib,tasks,spec}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 
-  s.add_dependency 'chef-provisioning'
+  s.add_runtime_dependency 'chef-provisioning', "~> 1.0"
 
   s.add_development_dependency "bundler", "~> 1.5"
-  s.add_development_dependency "rspec"
-  s.add_development_dependency "rake"
+  s.add_development_dependency "rspec",  "~> 0"
+  s.add_development_dependency "rake",  "~> 0"
 end

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -1,8 +1,9 @@
 Vagrant.configure("2") do |c|
+  c.ssh.insert_key = false
 
-   c.vm.define "provisioner" do |ne|
-    ne.vm.box = "opscode-ubuntu-12.04"
-    ne.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box"
+  c.vm.define "provisioner" do |ne|
+    ne.vm.box = "opscode-ubuntu-14.04"
+    ne.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box"
     ne.vm.hostname = "target.vagrantup.com"
     ne.vm.synced_folder "../../.", "/vagrant"
     ne.vm.network(:private_network, {:ip=>"192.168.33.171"})
@@ -12,8 +13,8 @@ Vagrant.configure("2") do |c|
   end
 
   c.vm.define "ssh-one" do |one|
-    one.vm.box = "opscode-ubuntu-12.04"
-    one.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box"
+    one.vm.box = "opscode-ubuntu-14.04"
+    one.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box"
     one.vm.hostname = "target01.vagrantup.com"
     one.vm.synced_folder ".", "/vagrant", disabled: true
     one.vm.network(:private_network, {:ip=>"192.168.33.122"})
@@ -23,8 +24,8 @@ Vagrant.configure("2") do |c|
   end
 
   c.vm.define "ssh-two" do |two|
-    two.vm.box = "opscode-ubuntu-12.04"
-    two.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box"
+    two.vm.box = "opscode-ubuntu-14.04"
+    two.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box"
     two.vm.hostname = "target02.vagrantup.com"
     two.vm.synced_folder ".", "/vagrant"
     two.vm.network(:private_network, {:ip=>"192.168.33.123"})

--- a/test/cookbooks/vagrant/recipes/sshone_2.rb
+++ b/test/cookbooks/vagrant/recipes/sshone_2.rb
@@ -1,0 +1,11 @@
+#
+# Cookbook Name:: vagrant
+# Recipe:: sshone
+#
+
+file '/tmp/sshone_2.txt' do
+	action :create
+	owner 'root'
+	group 'root'
+	mode '0644'
+end

--- a/test/cookbooks/vagrant/recipes/sshtwo_2.rb
+++ b/test/cookbooks/vagrant/recipes/sshtwo_2.rb
@@ -1,0 +1,11 @@
+#
+# Cookbook Name:: vagrant
+# Recipe:: sshone
+#
+
+file '/tmp/sshtwo_2.txt' do
+	action :create
+	owner 'root'
+	group 'root'
+	mode '0644'
+end

--- a/test/cookbooks/vagrant/recipes/test_destroy.rb
+++ b/test/cookbooks/vagrant/recipes/test_destroy.rb
@@ -1,0 +1,27 @@
+require 'chef/provisioning/ssh_driver'
+
+with_driver 'ssh'
+
+# Run this recipe AFTER running test_ssh or it will fail
+# It tests that we don't need to specify machine_options
+# for existing nodes
+machine "sshone" do
+  run_list [ 'recipe[vagrant::sshone_2]' ]
+  action :converge
+end
+
+machine "sshone" do
+  action :destroy
+end
+
+
+with_driver 'ssh:chef'
+
+machine "sshtwo" do
+  run_list [ 'recipe[vagrant::sshtwo_2]' ]
+  action :converge
+end
+
+machine "sshtwo" do
+  action :destroy
+end

--- a/test/cookbooks/vagrant/recipes/test_ssh.rb
+++ b/test/cookbooks/vagrant/recipes/test_ssh.rb
@@ -12,7 +12,6 @@ require 'chef/provisioning/ssh_driver'
 #       })
 
 # with_ssh_cluster "/home/js4/metal/chef-metal/docs/examples/drivers/ssh"
-# with_driver 'ssh
 with_driver 'ssh'
 
 machine "sshone" do
@@ -23,7 +22,10 @@ machine "sshone" do
     :username => 'vagrant',
     'ssh_options' => {
       #:password => 'vagrant'
-      :keys => ['/home/vagrant/.ssh/id_rsa']
+      
+      #:keys => ['/home/vagrant/.ssh/id_rsa']
+      :keys => ['~/.vagrant.d/insecure_private_key']
+
     },
     'options' => {
       'ssh_pty_enable' => true
@@ -47,10 +49,12 @@ end
 #                      :client_name => Chef::Config[:node_name],
 #                      :signing_key_filename => Chef::Config[:client_key]
 
+with_driver 'ssh:chef'
+
 machine "sshtwo" do
   # action :destroy
   action [:ready, :setup, :converge]
-  machine_options :transport_options => {
+  machine_options 'transport_options' => {
     :ip_address => '192.168.33.123',
     'username' => 'vagrant',
     :ssh_options => {

--- a/test/cookbooks/vagrant/recipes/test_winrm.rb
+++ b/test/cookbooks/vagrant/recipes/test_winrm.rb
@@ -16,9 +16,9 @@ require 'chef/provisioning/ssh_driver'
 
 with_driver 'ssh'
 
-with_chef_server "https://api.opscode.com/organizations/zzondlo",
-  :client_name => Chef::Config[:node_name],
-  :signing_key_filename => Chef::Config[:client_key]
+# with_chef_server "https://api.opscode.com/organizations/zzondlo",
+#  :client_name => Chef::Config[:node_name],
+#  :signing_key_filename => Chef::Config[:client_key]
 
 machine "winone" do
   # action :destroy
@@ -27,8 +27,8 @@ machine "winone" do
     'is_windows' => true,
     'host' => '192.168.33.100',
     'username' => 'vagrant',
-    'password' => 'vagrant'
-    # 'port' => 5985
+    'password' => 'vagrant',
+    'port' => 5985
   }
   recipe 'windows'
   converge true


### PR DESCRIPTION
To use this feature, specify a driver url of 'ssh:chef'. This makes it easier to use ssh provisioning from multiple locations. One example use case is using provisioning actions in different phases of Chef Delivery.

In support of above:
1. Some refactoring of driver.rb.
2. Fixed some warnings with gemspec.
3. Fixed tests for changed location of vagrant insecure key in vagrant 1.7+.
4. Updated readme for above and some out of date info.

Also fixes #29, removing need to specify machine_options in subsequent recipes referring to the same machines (e.g. to destroy them).